### PR TITLE
Override save method in Student model to run validators

### DIFF
--- a/models/roles/student.py
+++ b/models/roles/student.py
@@ -16,3 +16,11 @@ class Student(AbstractStudent):
         ],
         unique=True,
     )
+
+    def save(self, *args, **kwargs):
+        """
+        Override save method of Student class to automatically run validators of a model.
+        """
+
+        self.full_clean()
+        return super().save(*args, **kwargs)

--- a/models/roles/student.py
+++ b/models/roles/student.py
@@ -22,5 +22,6 @@ class Student(AbstractStudent):
         Override save method of Student class to automatically run validators of a model.
         """
 
-        self.full_clean()
+        if kwargs.get('run_validations', False):
+            self.full_clean()
         return super().save(*args, **kwargs)


### PR DESCRIPTION
Validators are not automatically run when `save` is called from python shell.

Source: https://docs.djangoproject.com/en/2.2/ref/validators/#how-validators-are-run