### PR TITLE
Override student save call to update the year whenever semester is updated

### DIFF
--- a/models/roles/student.py
+++ b/models/roles/student.py
@@ -16,3 +16,13 @@ class Student(AbstractStudent):
         ],
         unique=True,
     )
+
+    def save(self, *args, **kwargs):
+        """
+        Override .save call to update the year of the student whenever
+        the semester is updated
+        """
+        curent_semester = self.current_semester
+        self.current_year = int((curent_semester+1)/2)
+        super(Student, self).save(*args, **kwargs)
+


### PR DESCRIPTION
We are sure about how the year and semester work here at IIT Rookree. So just adding it for the shell.